### PR TITLE
Update svd2rust and remove riscv-rt dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ edition = "2018"
 [dependencies]
 bare-metal = "0.2.4"
 riscv = "0.6.0"
-riscv-rt = { version = "0.8.0", optional = true }
 vcell = "0.1.2"
 
 [features]
-rt = ["riscv-rt"]
+rt = []

--- a/librs-patch
+++ b/librs-patch
@@ -1,0 +1,2 @@
+#[cfg(feature = "rt")]
+extern crate riscv_rt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,6 @@
 #![no_std]
 extern crate bare_metal;
 extern crate riscv;
-#[cfg(feature = "rt")]
-extern crate riscv_rt;
 extern crate vcell;
 use core::marker::PhantomData;
 use core::ops::Deref;

--- a/update.sh
+++ b/update.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Before running this script, install the required software:
-# cargo install svd2rust --version=0.16.1
+# cargo install svd2rust --version=0.17.0
 # cargo install form --version=0.7.0
 # pip3 install --upgrade --user svdtools
 
@@ -15,3 +15,5 @@ svd2rust --target riscv -i GD32VF103.svd.patched
 form -i lib.rs -o src
 rm lib.rs
 cargo fmt
+grep -E 'feature = "rt"|extern crate riscv_rt' src/lib.rs | tee librs-patch
+grep -Ev 'feature = "rt"|extern crate riscv_rt' src/lib.rs > librs-temp && mv librs-temp src/lib.rs


### PR DESCRIPTION
I'm also creating a patch file, so we can know what we're removing from lib.rs during commits, which can be useful if a newer version of svd2rust does thing differently. Not sure if there is a better solution though.