### PR TITLE
Corrected the DMA1 peripheral memory address.

### DIFF
--- a/GD32VF103.svd
+++ b/GD32VF103.svd
@@ -18091,13 +18091,12 @@
       <name>DMA1</name>
       <description>Direct memory access controller</description>
        <groupName>DMA</groupName>
-      <baseAddress>0x40020000</baseAddress>
+      <baseAddress>0x40020400</baseAddress>
       <addressBlock>
         <offset>0x0</offset>
         <size>0x400</size>
         <usage>registers</usage>
       </addressBlock>
-      <baseAddress>0x40020400</baseAddress>
       <interrupt>
         <name>DMA1_Channel0</name>
         <value>75</value>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -532,7 +532,7 @@ pub struct DMA1 {
 unsafe impl Send for DMA1 {}
 impl DMA1 {
     #[doc = r"Pointer to the register block"]
-    pub const PTR: *const dma1::RegisterBlock = 0x4002_0000 as *const _;
+    pub const PTR: *const dma1::RegisterBlock = 0x4002_0400 as *const _;
     #[doc = r"Return the pointer to the register block"]
     #[inline(always)]
     pub const fn ptr() -> *const dma1::RegisterBlock {


### PR DESCRIPTION
In Section "9.5 DMA Register" of the User Manual (Chinese Edition, p. 134), the base address for DMA1 is correctly listed as 0x4002 0400.